### PR TITLE
chore(repo): harden release workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(actions)
+
+  - package-ecosystem: npm
+    directory: /eslint-plugin
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(deps)

--- a/.github/workflows/release-eslint-plugin.yml
+++ b/.github/workflows/release-eslint-plugin.yml
@@ -4,17 +4,21 @@ on:
   push:
     tags: ['eslint-plugin/v*']
 
-permissions:
-  contents: write
-  id-token: write
+concurrency:
+  group: release-eslint-plugin-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
@@ -31,13 +35,54 @@ jobs:
         working-directory: eslint-plugin
         run: npm test
 
+      - name: Typecheck
+        working-directory: eslint-plugin
+        run: npm run typecheck
+
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        working-directory: eslint-plugin
+        run: npm ci
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#eslint-plugin/v}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify tag matches package version
+        working-directory: eslint-plugin
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          PACKAGE_VERSION=$(node -p "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version $TAG_VERSION does not match package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build
+        working-directory: eslint-plugin
+        run: npm run build
+
       - name: Publish to npm
         working-directory: eslint-plugin
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --ignore-scripts
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -4,14 +4,19 @@ on:
   push:
     tags: ['plugin/v*']
 
-permissions:
-  contents: write
+concurrency:
+  group: release-plugin-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ Use the `/release` slash command. Artifacts are versioned and released independe
 
 **npm publishing** uses npm trusted publishing via GitHub Actions OIDC. Configure the npm package to trust this repository's release workflow before publishing.
 
+**Release hardening:** Protect the `main` branch and the `eslint-plugin/v*` and `plugin/v*` tag namespaces. Configure the `npm-publish` GitHub Environment with required reviewers before automated npm publishing, and keep GitHub Actions pinned by full commit SHA.
+
 ## Traceability
 
 After adding or changing opinions, regenerate the traceability matrix:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require maintainer review on all repository changes when branch protection enforces code owners.
+* @sethlivingston

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| `main` | Yes |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for security reports.
+
+Use GitHub's private vulnerability reporting for this repository when it is enabled. If private reporting is unavailable, contact the maintainer privately through GitHub before disclosing details publicly.
+
+Include:
+
+1. A clear description of the issue and impact
+2. Steps to reproduce or a proof of concept
+3. The affected package version or commit SHA
+4. Any suggested remediation or mitigation

--- a/eslint-plugin/src/configs/shared.ts
+++ b/eslint-plugin/src/configs/shared.ts
@@ -4,8 +4,40 @@ export function scopeConfigsToFiles(
   configs: readonly Linter.Config[],
   files: readonly string[],
 ): Linter.Config[] {
-  return configs.map(config => ({
-    ...config,
-    files: [...files],
-  }));
+  return configs.map(config => {
+    const scopedConfig: Linter.Config = {
+      ...config,
+      files: [...files],
+    };
+
+    if (config.languageOptions !== undefined) {
+      scopedConfig.languageOptions = {
+        ...config.languageOptions,
+        ...(config.languageOptions.globals === undefined
+          ? {}
+          : { globals: { ...config.languageOptions.globals } }),
+        ...(config.languageOptions.parserOptions === undefined
+          ? {}
+          : { parserOptions: { ...config.languageOptions.parserOptions } }),
+      };
+    }
+
+    if (config.linterOptions !== undefined) {
+      scopedConfig.linterOptions = { ...config.linterOptions };
+    }
+
+    if (config.plugins !== undefined) {
+      scopedConfig.plugins = { ...config.plugins };
+    }
+
+    if (config.rules !== undefined) {
+      scopedConfig.rules = { ...config.rules };
+    }
+
+    if (config.settings !== undefined) {
+      scopedConfig.settings = { ...config.settings };
+    }
+
+    return scopedConfig;
+  });
 }

--- a/eslint-plugin/src/configs/shared.ts
+++ b/eslint-plugin/src/configs/shared.ts
@@ -1,5 +1,19 @@
 import type { Linter } from 'eslint';
 
+function clonePlainValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(entry => clonePlainValue(entry)) as T;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, clonePlainValue(entry)]),
+    ) as T;
+  }
+
+  return value;
+}
+
 export function scopeConfigsToFiles(
   configs: readonly Linter.Config[],
   files: readonly string[],
@@ -15,15 +29,17 @@ export function scopeConfigsToFiles(
         ...config.languageOptions,
         ...(config.languageOptions.globals === undefined
           ? {}
-          : { globals: { ...config.languageOptions.globals } }),
+          : { globals: clonePlainValue(config.languageOptions.globals) }),
         ...(config.languageOptions.parserOptions === undefined
           ? {}
-          : { parserOptions: { ...config.languageOptions.parserOptions } }),
+          : {
+            parserOptions: clonePlainValue(config.languageOptions.parserOptions),
+          }),
       };
     }
 
     if (config.linterOptions !== undefined) {
-      scopedConfig.linterOptions = { ...config.linterOptions };
+      scopedConfig.linterOptions = clonePlainValue(config.linterOptions);
     }
 
     if (config.plugins !== undefined) {
@@ -31,11 +47,11 @@ export function scopeConfigsToFiles(
     }
 
     if (config.rules !== undefined) {
-      scopedConfig.rules = { ...config.rules };
+      scopedConfig.rules = clonePlainValue(config.rules);
     }
 
     if (config.settings !== undefined) {
-      scopedConfig.settings = { ...config.settings };
+      scopedConfig.settings = clonePlainValue(config.settings);
     }
 
     return scopedConfig;

--- a/eslint-plugin/src/configs/shared.ts
+++ b/eslint-plugin/src/configs/shared.ts
@@ -1,0 +1,11 @@
+import type { Linter } from 'eslint';
+
+export function scopeConfigsToFiles(
+  configs: readonly Linter.Config[],
+  files: readonly string[],
+): Linter.Config[] {
+  return configs.map(config => ({
+    ...config,
+    files: [...files],
+  }));
+}

--- a/eslint-plugin/src/configs/test.ts
+++ b/eslint-plugin/src/configs/test.ts
@@ -5,12 +5,20 @@ import { scopeConfigsToFiles } from './shared.js';
 const testFiles = [
   '**/*.test.ts',
   '**/*.test.tsx',
+  '**/*.test.mts',
+  '**/*.test.cts',
   '**/*.spec.ts',
   '**/*.spec.tsx',
+  '**/*.spec.mts',
+  '**/*.spec.cts',
   '**/__tests__/**/*.ts',
   '**/__tests__/**/*.tsx',
+  '**/__tests__/**/*.mts',
+  '**/__tests__/**/*.cts',
   'tests/**/*.ts',
   'tests/**/*.tsx',
+  'tests/**/*.mts',
+  'tests/**/*.cts',
 ] as const satisfies readonly string[];
 
 export function createTestConfig(plugin: ESLint.Plugin): Linter.Config[] {

--- a/eslint-plugin/src/configs/test.ts
+++ b/eslint-plugin/src/configs/test.ts
@@ -1,0 +1,28 @@
+import type { ESLint, Linter } from 'eslint';
+import { createStrictConfig } from './strict.js';
+import { scopeConfigsToFiles } from './shared.js';
+
+const testFiles = [
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
+  '**/__tests__/**/*.ts',
+  '**/__tests__/**/*.tsx',
+  'tests/**/*.ts',
+  'tests/**/*.tsx',
+] as const satisfies readonly string[];
+
+export function createTestConfig(plugin: ESLint.Plugin): Linter.Config[] {
+  return [
+    ...scopeConfigsToFiles(createStrictConfig(plugin), testFiles),
+    {
+      files: [...testFiles],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/prefer-readonly-parameter-types': 'off',
+        '@typescript-eslint/require-await': 'off',
+      },
+    },
+  ];
+}

--- a/eslint-plugin/src/configs/tooling.ts
+++ b/eslint-plugin/src/configs/tooling.ts
@@ -1,0 +1,45 @@
+import type { ESLint, Linter } from 'eslint';
+import { createStrictConfig } from './strict.js';
+import { scopeConfigsToFiles } from './shared.js';
+
+const toolingConfigNames = [
+  'eslint.config',
+  'vite.config',
+  'vitest.config',
+  'tsup.config',
+  'jest.config',
+  'playwright.config',
+  'rollup.config',
+  'webpack.config',
+  'postcss.config',
+  'prettier.config',
+  'stylelint.config',
+  'tailwind.config',
+  'commitlint.config',
+] as const;
+
+const toolingExtensions = [
+  'js',
+  'cjs',
+  'mjs',
+  'ts',
+  'tsx',
+  'cts',
+  'mts',
+] as const;
+
+const toolingFiles = toolingConfigNames.flatMap(configName =>
+  toolingExtensions.map(extension => `**/${configName}.${extension}`),
+);
+
+export function createToolingConfig(plugin: ESLint.Plugin): Linter.Config[] {
+  return [
+    ...scopeConfigsToFiles(createStrictConfig(plugin), toolingFiles),
+    {
+      files: [...toolingFiles],
+      rules: {
+        'import/no-default-export': 'off',
+      },
+    },
+  ];
+}

--- a/eslint-plugin/src/index.ts
+++ b/eslint-plugin/src/index.ts
@@ -2,6 +2,7 @@ import type { ESLint } from 'eslint';
 import { rules } from './rules/index.js';
 import { createStrictConfig } from './configs/strict.js';
 import { createTestConfig } from './configs/test.js';
+import { createToolingConfig } from './configs/tooling.js';
 
 // Replaced at build time by tsup define
 declare const PACKAGE_VERSION: string;
@@ -21,6 +22,7 @@ const plugin: ESLint.Plugin = {
 Object.assign(plugin.configs!, {
   strict: createStrictConfig(plugin),
   test: createTestConfig(plugin),
+  tooling: createToolingConfig(plugin),
 });
 
 export default plugin;

--- a/eslint-plugin/src/index.ts
+++ b/eslint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import type { ESLint } from 'eslint';
 import { rules } from './rules/index.js';
 import { createStrictConfig } from './configs/strict.js';
+import { createTestConfig } from './configs/test.js';
 
 // Replaced at build time by tsup define
 declare const PACKAGE_VERSION: string;
@@ -19,6 +20,7 @@ const plugin: ESLint.Plugin = {
 // Self-reference: configs need to reference the plugin object
 Object.assign(plugin.configs!, {
   strict: createStrictConfig(plugin),
+  test: createTestConfig(plugin),
 });
 
 export default plugin;

--- a/eslint-plugin/tests/configs/test.test.ts
+++ b/eslint-plugin/tests/configs/test.test.ts
@@ -1,5 +1,7 @@
+import type { Linter } from 'eslint';
 import { describe, it, expect } from 'vitest';
 import plugin from '../../src/index.js';
+import { scopeConfigsToFiles } from '../../src/configs/shared.js';
 
 describe('test config preset', () => {
   it('exports a test config as an array', () => {
@@ -44,25 +46,33 @@ describe('test config preset', () => {
   });
 
   it('does not share nested config objects with the strict preset', () => {
-    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
-    const testConfig = (plugin.configs as Record<string, unknown>).test as Array<Record<string, unknown>>;
-    const strictConfigWithRules = strict.find(config => config.rules !== undefined);
-    const scopedConfigWithRules = testConfig.find(
-      config => config.files !== undefined && config.rules !== undefined,
-    );
-    const strictConfigWithLanguageOptions = strict.find(config => config.languageOptions !== undefined);
-    const scopedConfigWithLanguageOptions = testConfig.find(
-      config => config.files !== undefined && config.languageOptions !== undefined,
-    );
+    const originalConfig: Linter.Config[] = [
+      {
+        languageOptions: {
+          parserOptions: {
+            projectService: {
+              allowDefaultProject: ['*.ts'],
+            },
+          },
+        },
+        rules: {
+          'no-console': 'error',
+        },
+      },
+    ];
+    const [scopedConfig] = scopeConfigsToFiles(originalConfig, ['**/*.test.ts']);
+    const originalParserOptions = (
+      originalConfig[0].languageOptions as { parserOptions?: { projectService?: { allowDefaultProject?: string[] } } }
+    ).parserOptions;
+    const scopedParserOptions = (
+      scopedConfig.languageOptions as { parserOptions?: { projectService?: { allowDefaultProject?: string[] } } }
+    ).parserOptions;
 
-    expect(testConfig).toHaveLength(strict.length + 1);
-    expect(strictConfigWithRules).toBeDefined();
-    expect(scopedConfigWithRules).toBeDefined();
-    expect(strictConfigWithLanguageOptions).toBeDefined();
-    expect(scopedConfigWithLanguageOptions).toBeDefined();
-    expect(scopedConfigWithRules?.rules).not.toBe(strictConfigWithRules?.rules);
-    expect(scopedConfigWithLanguageOptions?.languageOptions).not.toBe(
-      strictConfigWithLanguageOptions?.languageOptions,
+    expect(scopedConfig.rules).not.toBe(originalConfig[0].rules);
+    expect(scopedParserOptions).not.toBe(originalParserOptions);
+    expect(scopedParserOptions?.projectService).not.toBe(originalParserOptions?.projectService);
+    expect(scopedParserOptions?.projectService?.allowDefaultProject).not.toBe(
+      originalParserOptions?.projectService?.allowDefaultProject,
     );
   });
 });

--- a/eslint-plugin/tests/configs/test.test.ts
+++ b/eslint-plugin/tests/configs/test.test.ts
@@ -42,4 +42,27 @@ describe('test config preset', () => {
     expect(allRules['@typescript-eslint/require-await']).toBe('off');
     expect(allRules['@typescript-eslint/no-floating-promises']).toBe('error');
   });
+
+  it('does not share nested config objects with the strict preset', () => {
+    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
+    const testConfig = (plugin.configs as Record<string, unknown>).test as Array<Record<string, unknown>>;
+    const strictConfigWithRules = strict.find(config => config.rules !== undefined);
+    const scopedConfigWithRules = testConfig.find(
+      config => config.files !== undefined && config.rules !== undefined,
+    );
+    const strictConfigWithLanguageOptions = strict.find(config => config.languageOptions !== undefined);
+    const scopedConfigWithLanguageOptions = testConfig.find(
+      config => config.files !== undefined && config.languageOptions !== undefined,
+    );
+
+    expect(testConfig).toHaveLength(strict.length + 1);
+    expect(strictConfigWithRules).toBeDefined();
+    expect(scopedConfigWithRules).toBeDefined();
+    expect(strictConfigWithLanguageOptions).toBeDefined();
+    expect(scopedConfigWithLanguageOptions).toBeDefined();
+    expect(scopedConfigWithRules?.rules).not.toBe(strictConfigWithRules?.rules);
+    expect(scopedConfigWithLanguageOptions?.languageOptions).not.toBe(
+      strictConfigWithLanguageOptions?.languageOptions,
+    );
+  });
 });

--- a/eslint-plugin/tests/configs/test.test.ts
+++ b/eslint-plugin/tests/configs/test.test.ts
@@ -19,8 +19,12 @@ describe('test config preset', () => {
     expect(files).toContain('**/*.spec.ts');
     expect(files).toContain('**/*.test.tsx');
     expect(files).toContain('**/*.spec.tsx');
+    expect(files).toContain('**/*.test.mts');
+    expect(files).toContain('**/*.spec.cts');
     expect(files).toContain('tests/**/*.ts');
     expect(files).toContain('tests/**/*.tsx');
+    expect(files).toContain('tests/**/*.mts');
+    expect(files).toContain('tests/**/*.cts');
   });
 
   it('relaxes the selected ceremony-heavy rules for tests', () => {

--- a/eslint-plugin/tests/configs/test.test.ts
+++ b/eslint-plugin/tests/configs/test.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import plugin from '../../src/index.js';
+
+describe('test config preset', () => {
+  it('exports a test config as an array', () => {
+    expect(plugin.configs).toBeDefined();
+    const testConfig = (plugin.configs as Record<string, unknown>).test;
+    expect(Array.isArray(testConfig)).toBe(true);
+  });
+
+  it('targets conventional test file patterns including tsx cases', () => {
+    const testConfig = (plugin.configs as Record<string, unknown>).test as Array<Record<string, unknown>>;
+    const files = testConfig.flatMap(config => {
+      const configFiles = config.files as string[] | undefined;
+      return configFiles ?? [];
+    });
+
+    expect(files).toContain('**/*.test.ts');
+    expect(files).toContain('**/*.spec.ts');
+    expect(files).toContain('**/*.test.tsx');
+    expect(files).toContain('**/*.spec.tsx');
+    expect(files).toContain('tests/**/*.ts');
+    expect(files).toContain('tests/**/*.tsx');
+  });
+
+  it('relaxes the selected ceremony-heavy rules for tests', () => {
+    const testConfig = (plugin.configs as Record<string, unknown>).test as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+
+    for (const config of testConfig) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    expect(allRules['@typescript-eslint/explicit-function-return-type']).toBe('off');
+    expect(allRules['@typescript-eslint/prefer-readonly-parameter-types']).toBe('off');
+    expect(allRules['@typescript-eslint/require-await']).toBe('off');
+    expect(allRules['@typescript-eslint/no-floating-promises']).toBe('error');
+  });
+});

--- a/eslint-plugin/tests/configs/tooling.test.ts
+++ b/eslint-plugin/tests/configs/tooling.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import plugin from '../../src/index.js';
+
+describe('tooling config preset', () => {
+  it('exports a tooling config as an array', () => {
+    expect(plugin.configs).toBeDefined();
+    const tooling = (plugin.configs as Record<string, unknown>).tooling;
+    expect(Array.isArray(tooling)).toBe(true);
+  });
+
+  it('targets conventional config entrypoints', () => {
+    const tooling = (plugin.configs as Record<string, unknown>).tooling as Array<Record<string, unknown>>;
+    const files = tooling.flatMap(config => {
+      const configFiles = config.files as string[] | undefined;
+      return configFiles ?? [];
+    });
+
+    expect(files).toContain('**/eslint.config.ts');
+    expect(files).toContain('**/eslint.config.mjs');
+    expect(files).toContain('**/vite.config.ts');
+    expect(files).toContain('**/vitest.config.ts');
+    expect(files).toContain('**/tsup.config.ts');
+    expect(files).toContain('**/playwright.config.ts');
+    expect(files).toContain('**/prettier.config.cjs');
+    expect(files).toContain('**/tailwind.config.tsx');
+    expect(files).not.toContain('**/*.test.ts');
+    expect(files).not.toContain('src/**/*.ts');
+  });
+
+  it('relaxes import/no-default-export for tooling files only', () => {
+    const tooling = (plugin.configs as Record<string, unknown>).tooling as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+
+    for (const config of tooling) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    expect(allRules['import/no-default-export']).toBe('off');
+    expect(allRules['@typescript-eslint/no-floating-promises']).toBe('error');
+  });
+});

--- a/eslint-plugin/tests/integration/smoke.test.ts
+++ b/eslint-plugin/tests/integration/smoke.test.ts
@@ -21,7 +21,29 @@ function createESLintWithStrict(
         languageOptions: {
           parserOptions: {
             projectService: {
-              allowDefaultProject: ['*.ts'],
+              allowDefaultProject: ['*.ts', '*.tsx'],
+            },
+            tsconfigRootDir: __dirname,
+          },
+        },
+      },
+    ],
+  });
+}
+
+function createESLintWithConfigs(
+  configs: ESLint.ConfigData[],
+  allowDefaultProject: string[] = ['*.ts', '*.tsx'],
+): ESLint {
+  return new ESLint({
+    overrideConfigFile: true,
+    overrideConfig: [
+      ...configs,
+      {
+        languageOptions: {
+          parserOptions: {
+            projectService: {
+              allowDefaultProject,
             },
             tsconfigRootDir: __dirname,
           },
@@ -87,5 +109,38 @@ describe('strict preset integration', () => {
     );
     const ruleIds = results[0].messages.map(m => m.ruleId);
     expect(ruleIds).toContain('typescript-narrows/ban-barrel-files');
+  });
+});
+
+describe('test preset integration', () => {
+  it('relaxes ceremony-heavy rules in test files while keeping no-floating-promises enabled', async () => {
+    const strict = (plugin.configs as Record<string, unknown>)
+      .strict as ESLint.ConfigData[];
+    const testConfig = (plugin.configs as Record<string, unknown>)
+      .test as ESLint.ConfigData[];
+    const eslint = createESLintWithConfigs([...strict, ...testConfig]);
+
+    const results = await eslint.lintText(
+      `import { expect, it } from 'vitest';
+
+it('works', async () => {
+  const subject = (input: { value: string }) => {
+    input.value = 'next';
+  };
+
+  subject({ value: 'first' });
+  Promise.resolve('done');
+  expect(1).toBe(1);
+});
+`,
+      { filePath: join(__dirname, 'example.spec.tsx') },
+    );
+
+    const ruleIds = results[0].messages.map(m => m.ruleId);
+
+    expect(ruleIds).not.toContain('@typescript-eslint/explicit-function-return-type');
+    expect(ruleIds).not.toContain('@typescript-eslint/prefer-readonly-parameter-types');
+    expect(ruleIds).not.toContain('@typescript-eslint/require-await');
+    expect(ruleIds).toContain('@typescript-eslint/no-floating-promises');
   });
 });

--- a/eslint-plugin/tests/integration/smoke.test.ts
+++ b/eslint-plugin/tests/integration/smoke.test.ts
@@ -144,3 +144,47 @@ it('works', async () => {
     expect(ruleIds).toContain('@typescript-eslint/no-floating-promises');
   });
 });
+
+describe('tooling preset integration', () => {
+  it('allows default exports for tooling entrypoints', async () => {
+    const strict = (plugin.configs as Record<string, unknown>)
+      .strict as ESLint.ConfigData[];
+    const tooling = (plugin.configs as Record<string, unknown>)
+      .tooling as ESLint.ConfigData[];
+    const eslint = createESLintWithConfigs([...strict, ...tooling]);
+
+    const results = await eslint.lintText(
+      `export default {
+  test: {
+    globals: true,
+  },
+};
+`,
+      { filePath: join(__dirname, 'vitest.config.ts') },
+    );
+
+    const ruleIds = results[0].messages.map(m => m.ruleId);
+
+    expect(ruleIds).not.toContain('import/no-default-export');
+  });
+
+  it('keeps default exports disallowed for ordinary source files', async () => {
+    const strict = (plugin.configs as Record<string, unknown>)
+      .strict as ESLint.ConfigData[];
+    const tooling = (plugin.configs as Record<string, unknown>)
+      .tooling as ESLint.ConfigData[];
+    const eslint = createESLintWithConfigs([...strict, ...tooling]);
+
+    const results = await eslint.lintText(
+      `export default function greet(): string {
+  return 'hi';
+}
+`,
+      { filePath: join(__dirname, 'source.ts') },
+    );
+
+    const ruleIds = results[0].messages.map(m => m.ruleId);
+
+    expect(ruleIds).toContain('import/no-default-export');
+  });
+});


### PR DESCRIPTION
## Summary
- pin release workflow actions to full commit SHAs and disable credential persistence on checkout
- split npm release into validate and publish jobs, add version/tag verification, and wire publish through the `npm-publish` environment
- add repo-level hardening files: `CODEOWNERS`, `SECURITY.md`, and Dependabot updates for GitHub Actions and npm
- document the remaining release hardening requirements in `CLAUDE.md`

## Follow-up settings outside the repo
1. Protect `main`, `eslint-plugin/v*`, and `plugin/v*` with branch/tag rulesets
2. Configure the `npm-publish` environment with required reviewers and confirm npm trusted publisher scope/2FA settings
