### PR TITLE
chore(release): sync 1.1.0 bump and protected-main guidance

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -12,9 +12,11 @@ The user provides `$ARGUMENTS` which should specify what to release. Examples:
 ### For the ESLint plugin (`eslint-plugin/v*` tags):
 
 1. Update `eslint-plugin/package.json` version field to the new version
-2. Run `cd eslint-plugin && npm run build && npm test` to verify everything passes
-3. Commit: `chore(eslint-plugin): bump version to {version}`
-4. Tag: `git tag eslint-plugin/v{version}`
+2. Run `cd eslint-plugin && npm run build && npm test && npm run typecheck` to verify everything passes
+3. Commit on a branch: `chore(eslint-plugin): bump version to {version}`
+4. Open and merge a PR so the version bump lands on protected `main`
+5. Fast-forward local `main` to the merged commit
+6. Tag from `main`: `git tag eslint-plugin/v{version}`
 
 ### For the plugin (`plugin/v*` tags):
 
@@ -24,11 +26,11 @@ The user provides `$ARGUMENTS` which should specify what to release. Examples:
 
 ### After tagging:
 
-1. Push the commit(s) and tag(s): `git push && git push --tags`
+1. Push only the tag(s): `git push origin refs/tags/eslint-plugin/v{version}` and/or `git push origin refs/tags/plugin/v{version}`
 2. Report what was released and remind the user:
    - For eslint-plugin: The GitHub Action will run tests, publish to npm, and create a GitHub Release
    - For plugin: The GitHub Action will create a GitHub Release
-   - The user needs `NPM_TOKEN` configured as a repository secret for npm publishing
+   - npm publishing uses trusted publishing via GitHub Actions OIDC, so the npm package must trust this repository's release workflow
 
 ## Tag Convention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,14 +39,16 @@ Use the `/add-opinion` slash command. It walks through creating the corpus file,
 Use the `/release` slash command. Artifacts are versioned and released independently via prefixed git tags.
 
 ```
-/release eslint-plugin 1.1.0        # release only the plugin
+/release eslint-plugin 1.1.0        # release only the ESLint plugin
 /release plugin 1.1.0                # release only the plugin
 /release eslint-plugin 1.1.0 plugin 1.1.0  # release both
 ```
 
+**Protected-main release flow:** do not push release commits directly to `main`. For `eslint-plugin` releases, bump `eslint-plugin/package.json` on a branch, validate it, open and merge the PR, then fast-forward local `main` and push only the release tag(s). For `plugin`-only releases, tag the desired commit already on `main`.
+
 **Tag convention:** `eslint-plugin/v{semver}` and `plugin/v{semver}`. Pushing a tag triggers the matching GitHub Actions workflow in `.github/workflows/`.
 
-**npm publishing** uses npm trusted publishing via GitHub Actions OIDC. Configure the npm package to trust this repository's release workflow before publishing.
+**npm publishing** uses npm trusted publishing via GitHub Actions OIDC. Configure the npm package to trust this repository's release workflow before publishing; no long-lived `NPM_TOKEN` repository secret should be required.
 
 **Release hardening:** Protect the `main` branch and the `eslint-plugin/v*` and `plugin/v*` tag namespaces. Configure the `npm-publish` GitHub Environment with required reviewers before automated npm publishing, and keep GitHub Actions pinned by full commit SHA.
 

--- a/eslint-plugin/package-lock.json
+++ b/eslint-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0",

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- merge the `eslint-plugin` 1.1.0 version bump back into `main`
- update release guidance for protected `main` so future releases land the bump commit before tags are pushed
- update the local `/release` skill to match npm trusted publishing via GitHub Actions OIDC

## Why
The `eslint-plugin/v1.1.0` and `plugin/v1.1.0` tags were pushed from the release commit because `main` is protected. This PR brings `main` back in sync with the published release and documents the correct workflow for future releases.