### PR TITLE
chore(eslint-plugin): bump version to 1.1.1

### DIFF
--- a/eslint-plugin/package-lock.json
+++ b/eslint-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0",

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Bump the ESLint plugin package version to `1.1.1` for the follow-up release after the failed `1.1.0` publish.

## Why
`eslint-plugin/v1.1.0` failed before npm publish due to a TypeScript 6 declaration-build issue. The fix is already merged on `main`, so this PR advances the package version for the corrected release.