### PR TITLE
fix(eslint-plugin): allow __NAME__ injected constants

### DIFF
--- a/docs/opinions/naming-convention.md
+++ b/docs/opinions/naming-convention.md
@@ -13,7 +13,7 @@ lint:
 
 ## Stance
 
-Use PascalCase for types, interfaces, classes, and enums. Use camelCase for variables, functions, methods, and parameters. Use UPPER_CASE for module-level constants.
+Use PascalCase for types, interfaces, classes, and enums. Use camelCase for variables, functions, methods, and parameters. Use UPPER_CASE for module-level constants. For build-time injected constants supplied by tooling, `__NAME__` is also allowed.
 
 ## Why
 
@@ -28,6 +28,7 @@ interface UserProfile {
 
 const maxRetries = 3;
 const MAX_TIMEOUT = 5000;
+declare const __APP_RUNTIME_TARGET__: 'browser' | 'node';
 
 function formatName(user: UserProfile): string {
   return user.displayName;

--- a/eslint-plugin/README.md
+++ b/eslint-plugin/README.md
@@ -34,6 +34,8 @@ Use the presets together in that order:
 | `configs.test` | Test files and test helpers | Relaxes ceremony-heavy rules like explicit return types, readonly parameter types, and `require-await`, while keeping safety rules like `no-floating-promises` |
 | `configs.tooling` | Tooling and config entrypoints | Keeps strict behavior but turns off `import/no-default-export` for conventional config files |
 
+The strict preset also allows build-time injected constants that follow `^__[_A-Z0-9]+__$`, including declared globals and object-literal `define` maps.
+
 ## What's Included
 
 - 20+ typescript-eslint rules configured to opinionated defaults

--- a/eslint-plugin/src/configs/strict.ts
+++ b/eslint-plugin/src/configs/strict.ts
@@ -2,6 +2,8 @@ import tseslint from 'typescript-eslint';
 import importPlugin from 'eslint-plugin-import-x';
 import type { ESLint, Linter } from 'eslint';
 
+const INJECTED_CONSTANT_REGEX = '^__[_A-Z0-9]+__$'
+
 export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
   return [
     ...tseslint.configs.strictTypeChecked,
@@ -62,6 +64,17 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
         '@typescript-eslint/strict-boolean-expressions': 'error',
         '@typescript-eslint/naming-convention': [
           'error',
+          {
+            selector: 'variable',
+            modifiers: ['const', 'global'],
+            filter: { regex: INJECTED_CONSTANT_REGEX, match: true },
+            format: null,
+          },
+          {
+            selector: 'objectLiteralProperty',
+            filter: { regex: INJECTED_CONSTANT_REGEX, match: true },
+            format: null,
+          },
           { selector: 'default', format: ['camelCase'] },
           { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
           {

--- a/eslint-plugin/tests/configs/strict.test.ts
+++ b/eslint-plugin/tests/configs/strict.test.ts
@@ -37,6 +37,23 @@ describe('strict config preset', () => {
     expect(allRules['@typescript-eslint/prefer-readonly']).toBeDefined();
     expect(allRules['@typescript-eslint/strict-boolean-expressions']).toBeDefined();
     expect(allRules['@typescript-eslint/naming-convention']).toBeDefined();
+
+    const namingConvention = allRules['@typescript-eslint/naming-convention'] as [
+      string,
+      ...Array<Record<string, unknown>>,
+    ];
+
+    expect(namingConvention.slice(1)).toContainEqual({
+      selector: 'variable',
+      modifiers: ['const', 'global'],
+      filter: { regex: '^__[_A-Z0-9]+__$', match: true },
+      format: null,
+    });
+    expect(namingConvention.slice(1)).toContainEqual({
+      selector: 'objectLiteralProperty',
+      filter: { regex: '^__[_A-Z0-9]+__$', match: true },
+      format: null,
+    });
   });
 
   it('configures import plugin rules', () => {

--- a/eslint-plugin/tests/integration/smoke.test.ts
+++ b/eslint-plugin/tests/integration/smoke.test.ts
@@ -110,6 +110,24 @@ describe('strict preset integration', () => {
     const ruleIds = results[0].messages.map(m => m.ruleId);
     expect(ruleIds).toContain('typescript-narrows/ban-barrel-files');
   });
+
+  it('allows __NAME__ build-time injected constants in strict preset', async () => {
+    const eslint = createESLintWithStrict();
+    const results = await eslint.lintText(
+      `declare const __ONEWAY_HTTP_EXPECTED_ROOT_TARGET__: 'browser' | 'node';
+
+export const define = {
+  __ONEWAY_HTTP_EXPECTED_ROOT_TARGET__: JSON.stringify('browser'),
+};
+
+export const expectedRootTarget = __ONEWAY_HTTP_EXPECTED_ROOT_TARGET__;
+`,
+      { filePath: join(__dirname, 'injected-constants.ts') },
+    );
+
+    const ruleIds = results[0].messages.map(m => m.ruleId);
+    expect(ruleIds).not.toContain('@typescript-eslint/naming-convention');
+  });
 });
 
 describe('test preset integration', () => {


### PR DESCRIPTION
## Summary
- allow `^__[_A-Z0-9]+__$` build-time injected constants in the strict preset
- cover both declared globals and object-literal `define` keys in tests
- document the injected-constant exception in the plugin README and naming opinion

Closes #16.

## Release note
This branch can also carry the `eslint-plugin` version bump before merge if we want to use the same PR for the release prep flow.