### PR TITLE
chore(eslint-plugin): bump version to 1.2.0

### DIFF
--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps eslint-plugin to v1.2.0.

Changes in this release:
- Removed `prefer-readonly-parameter-types` from the strict preset (closes #25)
- Added `requiresQuotes` exception to `naming-convention` rule (closes #26)