### PR TITLE
chore(eslint-plugin): bump version to 1.2.1

### DIFF
--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps eslint-plugin to v1.2.1. Includes the release workflow fix (--notes-file) from the v1.2.0 run.