### PR TITLE
fix: address GitHub issues #29–#33 (no-unsafe-type-assertion rule + strict config fixes)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -128,6 +128,7 @@ None yet.
 | 260317-j2m | Update add-opinion command with ESLint integration steps (5-6) | 2026-03-17 | 618210c | [260317-j2m-update-add-opinion-command-to-carry-opin](./quick/260317-j2m-update-add-opinion-command-to-carry-opin/) |
 | 260317-mtj | Replace fragile specific counts in consumer-facing .md files with approximate language | 2026-03-17 | dddb747 | [260317-mtj-replace-fragile-specific-counts-in-md-fi](./quick/260317-mtj-replace-fragile-specific-counts-in-md-fi/) |
 | 260317-r4a | Scope ESLint plugin npm package name to @sethlivingston | 2026-03-17 | 9b57bbd | [260317-r4a-scope-the-eslint-plugin-to-sethlivingsto](./quick/260317-r4a-scope-the-eslint-plugin-to-sethlivingsto/) |
+| 260505-t76 | Address GitHub issues #29-#33: add no-unsafe-type-assertion rule, fix strict config (consistent-type-assertions, naming-convention, no-unnecessary-condition, no-unused-vars) | 2026-05-05 | d1b6691 | [260505-t76-address-vetted-github-issues-add-no-unsa](./quick/260505-t76-address-vetted-github-issues-add-no-unsa/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-PLAN.md
+++ b/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-PLAN.md
@@ -1,0 +1,370 @@
+---
+phase: quick/260505-t76
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+  - eslint-plugin/src/rules/index.ts
+  - eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
+  - eslint-plugin/src/configs/strict.ts
+  - eslint-plugin/tests/configs/strict.test.ts
+autonomous: true
+requirements:
+  - issue-29
+  - issue-30
+  - issue-31
+  - issue-32
+  - issue-33
+
+must_haves:
+  truths:
+    - "no-unsafe-type-assertion rule reports on direct casts (value as string) and passes for as unknown, as unknown as T, and as const"
+    - "consistent-type-assertions uses assertionStyle:'as' + objectLiteralTypeAssertions:'never' (not 'never' alone)"
+    - "naming-convention allows classProperty leadingUnderscore and PascalCase for const global object variables"
+    - "no-unnecessary-condition allows constant loop conditions"
+    - "no-unused-vars ignores underscore-prefixed args, caught errors, vars, and rest siblings"
+  artifacts:
+    - path: "eslint-plugin/src/rules/no-unsafe-type-assertion.ts"
+      provides: "Custom ESLint rule implementation"
+      exports: ["noUnsafeTypeAssertion"]
+    - path: "eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts"
+      provides: "Rule tester with valid/invalid cases"
+    - path: "eslint-plugin/src/rules/index.ts"
+      provides: "Rule registry including no-unsafe-type-assertion"
+      contains: "no-unsafe-type-assertion"
+    - path: "eslint-plugin/src/configs/strict.ts"
+      provides: "Updated strict config with all 5 issue fixes"
+  key_links:
+    - from: "eslint-plugin/src/rules/no-unsafe-type-assertion.ts"
+      to: "eslint-plugin/src/rules/index.ts"
+      via: "named export registered in rules map"
+    - from: "eslint-plugin/src/rules/index.ts"
+      to: "eslint-plugin/src/configs/strict.ts"
+      via: "plugin rules object consumed by createStrictConfig"
+---
+
+<objective>
+Address 5 vetted GitHub issues: create the `no-unsafe-type-assertion` custom rule (#29), then fix four strict config entries (#30 consistent-type-assertions, #31 naming-convention, #32 no-unnecessary-condition, #33 no-unused-vars).
+
+Purpose: Close open issues, improve plugin ergonomics, and make the strict config more practical without sacrificing safety.
+Output: New rule file + test, updated rule registry, updated strict config, updated config test assertions.
+</objective>
+
+<execution_context>
+@~/.copilot/get-shit-done/workflows/execute-plan.md
+@~/.copilot/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@eslint-plugin/src/utils/create-rule.ts
+@eslint-plugin/src/rules/ban-enums.ts
+@eslint-plugin/src/rules/index.ts
+@eslint-plugin/src/configs/strict.ts
+@eslint-plugin/tests/rules/ban-enums.test.ts
+@eslint-plugin/tests/configs/strict.test.ts
+
+<interfaces>
+<!-- From eslint-plugin/src/utils/create-rule.ts -->
+```typescript
+export interface NarrowsRuleDocs {
+  description: string;
+  opinionId: string;
+  recommended: boolean;
+  requiresTypeChecking: boolean;
+}
+export const createRule = ESLintUtils.RuleCreator<NarrowsRuleDocs>(
+  name => `https://github.com/sethlivingston/the-typescript-narrows/blob/main/docs/opinions/${name}.md`,
+);
+```
+
+<!-- From eslint-plugin/src/rules/ban-enums.ts (template pattern) -->
+```typescript
+import { createRule } from '../utils/create-rule.js';
+export const banEnums = createRule({
+  name: 'ban-enums',
+  meta: { type: 'suggestion', docs: { opinionId, recommended, requiresTypeChecking }, messages: { banned: '...' }, schema: [] },
+  defaultOptions: [],
+  create(context) { return { TSEnumDeclaration(node) { context.report({ node, messageId: 'banned' }); } }; },
+});
+```
+
+<!-- From eslint-plugin/tests/rules/ban-enums.test.ts (test template) -->
+```typescript
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { banEnums } from '../../src/rules/ban-enums.js';
+const ruleTester = new RuleTester();
+ruleTester.run('ban-enums', banEnums, { valid: [...], invalid: [{ code: '...', errors: [{ messageId: 'banned' as const }] }] });
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create no-unsafe-type-assertion rule, test, and register (#29)</name>
+  <files>
+    eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+    eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
+    eslint-plugin/src/rules/index.ts
+  </files>
+  <behavior>
+    - Valid: `const u = value as unknown;` — TSUnknownKeyword annotation → no report
+    - Valid: `const b = (value as unknown) as BodyOpaque;` — outer expression is TSAsExpression with TSUnknownKeyword annotation → no report
+    - Valid: `const c = { x: 1 } as const;` — TSTypeOperator with operator 'const' → no report
+    - Valid: `const d = [1, 2] as const;` — same as above → no report
+    - Invalid: `const a = value as string;` → reports `unsafeAssertion`
+    - Invalid: `const e = result as { kind: string };` → reports `unsafeAssertion`
+    - Invalid: `const f = {} as SomeInterface;` → reports `unsafeAssertion`
+    - Invalid: `const g = value as SomeClass;` → reports `unsafeAssertion`
+  </behavior>
+  <action>
+    **Step 1 — Write test first (RED):**
+
+    Create `eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts` mirroring the ban-enums test pattern:
+    ```typescript
+    import { RuleTester } from '@typescript-eslint/rule-tester';
+    import { noUnsafeTypeAssertion } from '../../src/rules/no-unsafe-type-assertion.js';
+
+    const ruleTester = new RuleTester();
+
+    ruleTester.run('no-unsafe-type-assertion', noUnsafeTypeAssertion, {
+      valid: [
+        'const u = value as unknown;',
+        'const b = (value as unknown) as BodyOpaque;',
+        'const c = { x: 1 } as const;',
+        'const d = [1, 2] as const;',
+      ],
+      invalid: [
+        { code: 'const a = value as string;', errors: [{ messageId: 'unsafeAssertion' as const }] },
+        { code: 'const e = result as { kind: string };', errors: [{ messageId: 'unsafeAssertion' as const }] },
+        { code: 'const f = {} as SomeInterface;', errors: [{ messageId: 'unsafeAssertion' as const }] },
+        { code: 'const g = value as SomeClass;', errors: [{ messageId: 'unsafeAssertion' as const }] },
+      ],
+    });
+    ```
+
+    **Step 2 — Create rule (GREEN):**
+
+    Create `eslint-plugin/src/rules/no-unsafe-type-assertion.ts`:
+    ```typescript
+    import { createRule } from '../utils/create-rule.js';
+
+    export const noUnsafeTypeAssertion = createRule({
+      name: 'no-unsafe-type-assertion',
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Disallow unsafe type assertions; require as unknown as T double-cast pattern',
+          opinionId: 'no-unsafe-type-assertion',
+          recommended: true,
+          requiresTypeChecking: false,
+        },
+        messages: {
+          unsafeAssertion:
+            'Unsafe type assertion. Use `as unknown as T` to cross a type boundary explicitly, or eliminate the assertion with a type guard.',
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context) {
+        return {
+          TSAsExpression(node) {
+            const typeAnnotation = node.typeAnnotation;
+
+            // Allow: value as unknown
+            if (typeAnnotation.type === 'TSUnknownKeyword') return;
+
+            // Allow: value as const
+            if (
+              typeAnnotation.type === 'TSTypeOperator' &&
+              typeAnnotation.operator === 'const'
+            ) return;
+
+            // Allow: (value as unknown) as T
+            if (
+              node.expression.type === 'TSAsExpression' &&
+              node.expression.typeAnnotation.type === 'TSUnknownKeyword'
+            ) return;
+
+            context.report({ node, messageId: 'unsafeAssertion' });
+          },
+        };
+      },
+    });
+    ```
+
+    **Step 3 — Register in index.ts:**
+
+    Update `eslint-plugin/src/rules/index.ts` to add the new rule:
+    ```typescript
+    import { banEnums } from './ban-enums.js';
+    import { banBarrelFiles } from './ban-barrel-files.js';
+    import { noUnsafeTypeAssertion } from './no-unsafe-type-assertion.js';
+
+    export const rules = {
+      'ban-enums': banEnums,
+      'ban-barrel-files': banBarrelFiles,
+      'no-unsafe-type-assertion': noUnsafeTypeAssertion,
+    };
+    ```
+  </action>
+  <verify>
+    <automated>cd eslint-plugin && npx vitest run tests/rules/no-unsafe-type-assertion.test.ts</automated>
+  </verify>
+  <done>All 4 valid cases pass without errors, all 4 invalid cases report `unsafeAssertion`. Rule exported and registered in index.ts.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Fix strict config for issues #30/#31/#32/#33 and update strict.test.ts</name>
+  <files>
+    eslint-plugin/src/configs/strict.ts
+    eslint-plugin/tests/configs/strict.test.ts
+  </files>
+  <action>
+    Make four targeted edits to `eslint-plugin/src/configs/strict.ts`:
+
+    **#29 — Add no-unsafe-type-assertion to custom rules block:**
+    Change the `// typescript-narrows custom rules (2)` comment to `(3)` and add:
+    ```typescript
+    'typescript-narrows/no-unsafe-type-assertion': 'error',
+    ```
+
+    **#30 — consistent-type-assertions (depends on #29 being present):**
+    Replace:
+    ```typescript
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      { assertionStyle: 'never' },
+    ],
+    ```
+    With:
+    ```typescript
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'never',
+      },
+    ],
+    ```
+
+    **#31 — naming-convention fixes:**
+    Insert a `classProperty` entry BEFORE `{ selector: 'default', format: ['camelCase'] }`:
+    ```typescript
+    {
+      selector: 'classProperty',
+      format: ['camelCase'],
+      leadingUnderscore: 'allow',
+    },
+    ```
+    Insert a const-global-object variable entry BEFORE `{ selector: 'variable', format: ['camelCase', 'UPPER_CASE'] }`:
+    ```typescript
+    {
+      selector: 'variable',
+      modifiers: ['const', 'global'],
+      types: ['object'],
+      format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+    },
+    ```
+
+    **#32 — no-unnecessary-condition:**
+    Replace:
+    ```typescript
+    '@typescript-eslint/no-unnecessary-condition': 'error',
+    ```
+    With:
+    ```typescript
+    '@typescript-eslint/no-unnecessary-condition': [
+      'error',
+      { allowConstantLoopConditions: true },
+    ],
+    ```
+
+    **#33 — no-unused-vars:**
+    Add after `'@typescript-eslint/only-throw-error': 'error',`:
+    ```typescript
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'all',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
+    ],
+    ```
+
+    **Update strict.test.ts** — add assertions verifying the new and changed rules. Add a new `it` block (or extend the existing "configures opinionated @typescript-eslint overrides" block) to assert:
+    - `allRules['typescript-narrows/no-unsafe-type-assertion']` equals `'error'`
+    - `allRules['@typescript-eslint/consistent-type-assertions']` deep-equals `['error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }]`
+    - `allRules['@typescript-eslint/no-unnecessary-condition']` deep-equals `['error', { allowConstantLoopConditions: true }]`
+    - `allRules['@typescript-eslint/no-unused-vars']` deep-equals `['error', { args: 'all', argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_', varsIgnorePattern: '^_', ignoreRestSiblings: true }]`
+    - naming-convention array contains `{ selector: 'classProperty', format: ['camelCase'], leadingUnderscore: 'allow' }`
+    - naming-convention array contains `{ selector: 'variable', modifiers: ['const', 'global'], types: ['object'], format: ['camelCase', 'UPPER_CASE', 'PascalCase'] }`
+
+    Add these as a new `it('configures issue fixes #29-#33', ...)` block after the existing tests.
+  </action>
+  <verify>
+    <automated>cd eslint-plugin && npx vitest run tests/configs/strict.test.ts</automated>
+  </verify>
+  <done>All strict.test.ts assertions pass. strict.ts reflects all 5 issue changes: no-unsafe-type-assertion enabled, consistent-type-assertions uses 'as'+objectLiteralTypeAssertions, naming-convention has classProperty and PascalCase-object entries, no-unnecessary-condition allows constant loops, no-unused-vars ignores underscore-prefixed identifiers.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full verify — typecheck + build + all tests</name>
+  <files></files>
+  <action>
+    Run the full verify script from the eslint-plugin directory to confirm everything compiles, builds, and all tests pass end-to-end:
+    ```
+    cd eslint-plugin && npm run verify
+    ```
+    Fix any TypeScript compile errors (likely none — the AST node types from `@typescript-eslint/utils` should handle TSAsExpression, TSUnknownKeyword, TSTypeOperator correctly). If typecheck fails on the rule file, import the `TSAsExpression` type from `@typescript-eslint/utils` and narrow with type guards as needed.
+  </action>
+  <verify>
+    <automated>cd eslint-plugin && npm run verify</automated>
+  </verify>
+  <done>`npm run verify` exits 0: typecheck clean, build succeeds, all tests (including new rule test and updated strict config test) pass.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| rule input → AST visitor | Rule receives AST nodes from the parser; no user-supplied data at runtime |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-t76-01 | Tampering | no-unsafe-type-assertion AST visitor | accept | Rule is read-only lint analysis; no data mutation, no persistent state |
+| T-t76-02 | Denial of Service | TSAsExpression visitor on large files | accept | ESLint visitor overhead is negligible; no recursive traversal in rule logic |
+</threat_model>
+
+<verification>
+```bash
+cd eslint-plugin && npm run verify
+```
+All checks must pass: `tsc --noEmit`, `tsup` build, `vitest run` (includes new rule test and updated strict config tests).
+</verification>
+
+<success_criteria>
+- `eslint-plugin/src/rules/no-unsafe-type-assertion.ts` exists and exports `noUnsafeTypeAssertion`
+- `eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts` passes all valid/invalid cases
+- `eslint-plugin/src/rules/index.ts` registers `'no-unsafe-type-assertion': noUnsafeTypeAssertion`
+- `strict.ts` has `'typescript-narrows/no-unsafe-type-assertion': 'error'`
+- `strict.ts` `consistent-type-assertions` uses `assertionStyle: 'as'` + `objectLiteralTypeAssertions: 'never'`
+- `strict.ts` `naming-convention` includes classProperty leadingUnderscore entry and PascalCase const-global-object entry
+- `strict.ts` `no-unnecessary-condition` has `allowConstantLoopConditions: true`
+- `strict.ts` `no-unused-vars` has underscore-ignore patterns for args/caughtErrors/vars with ignoreRestSiblings
+- `npm run verify` exits 0 in eslint-plugin directory
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-01-SUMMARY.md`
+</output>

--- a/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-REVIEW.md
+++ b/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-REVIEW.md
@@ -1,0 +1,38 @@
+---
+phase: quick/260505-t76
+review_depth: standard
+files_reviewed: 5
+blockers: 0
+warnings: 3
+info: 2
+---
+
+# Code Review: 260505-t76
+
+**Files reviewed:** 5 | **Blockers:** 0 | **Warnings:** 3 | **Info:** 2
+
+## Cleared (no issues)
+
+- **`as const` AST heuristic** — `TSTypeReference.typeName.name === 'const'` is confirmed correct. `@typescript-eslint`'s own `consistent-type-assertions` rule uses an identical `isConst` function internally.
+- **`consistent-type-assertions` + `as const` conflict** — `objectLiteralTypeAssertions: 'never'` explicitly exempts `as const`. No conflict.
+- **`naming-convention` vs `varsIgnorePattern: '^_'`** — `leadingUnderscore` defaults to `"allow"` in `naming-convention`; `_unused` vars satisfy both rules.
+- **Double-cast parenthesization** — Parser strips parens in expression positions; `((value as unknown)) as T` produces the expected AST.
+
+## ⚠️ Warnings
+
+### WR-01 — `as never` untested
+`value as never` is flagged by the rule but has no test case. Exhaustiveness-check patterns (e.g., `assertNever(x as never)`) will get unexpected errors.
+
+### WR-02 — Chained unsafe cast not tested
+`(value as Foo) as Bar` should produce 2 independent errors. Behavior is unverified.
+
+### WR-03 — Double-flagging on object literal assertions
+`{} as SomeType` is flagged by both `consistent-type-assertions` (objectLiteralTypeAssertions: 'never') and `no-unsafe-type-assertion`, producing contradictory fix suggestions. `objectLiteralTypeAssertions: 'never'` is fully subsumed by the new rule.
+
+## ℹ️ Info
+
+### IN-01 — Missing comment on `as const` detection
+No inline comment explaining why `TSTypeReference` is used instead of `TSTypeOperator` for `as const` in @typescript-eslint v8.
+
+### IN-02 — `value as unknown as T` (no parens) not in valid cases
+The no-parens form is the same AST as the tested form but is not covered by tests.

--- a/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-REVIEW.md
+++ b/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-REVIEW.md
@@ -3,36 +3,22 @@ phase: quick/260505-t76
 review_depth: standard
 files_reviewed: 5
 blockers: 0
-warnings: 3
-info: 2
+warnings: 0
+info: 0
 ---
 
 # Code Review: 260505-t76
 
-**Files reviewed:** 5 | **Blockers:** 0 | **Warnings:** 3 | **Info:** 2
+**Files reviewed:** 5 | **Blockers:** 0 | **Warnings:** 0 | **Info:** 0
 
-## Cleared (no issues)
+## All findings resolved
 
-- **`as const` AST heuristic** — `TSTypeReference.typeName.name === 'const'` is confirmed correct. `@typescript-eslint`'s own `consistent-type-assertions` rule uses an identical `isConst` function internally.
-- **`consistent-type-assertions` + `as const` conflict** — `objectLiteralTypeAssertions: 'never'` explicitly exempts `as const`. No conflict.
-- **`naming-convention` vs `varsIgnorePattern: '^_'`** — `leadingUnderscore` defaults to `"allow"` in `naming-convention`; `_unused` vars satisfy both rules.
-- **Double-cast parenthesization** — Parser strips parens in expression positions; `((value as unknown)) as T` produces the expected AST.
+All findings from the initial review were addressed:
 
-## ⚠️ Warnings
-
-### WR-01 — `as never` untested
-`value as never` is flagged by the rule but has no test case. Exhaustiveness-check patterns (e.g., `assertNever(x as never)`) will get unexpected errors.
-
-### WR-02 — Chained unsafe cast not tested
-`(value as Foo) as Bar` should produce 2 independent errors. Behavior is unverified.
-
-### WR-03 — Double-flagging on object literal assertions
-`{} as SomeType` is flagged by both `consistent-type-assertions` (objectLiteralTypeAssertions: 'never') and `no-unsafe-type-assertion`, producing contradictory fix suggestions. `objectLiteralTypeAssertions: 'never'` is fully subsumed by the new rule.
-
-## ℹ️ Info
-
-### IN-01 — Missing comment on `as const` detection
-No inline comment explaining why `TSTypeReference` is used instead of `TSTypeOperator` for `as const` in @typescript-eslint v8.
-
-### IN-02 — `value as unknown as T` (no parens) not in valid cases
-The no-parens form is the same AST as the tested form but is not covered by tests.
+| ID | Finding | Resolution |
+|----|---------|------------|
+| WR-01 | `as never` untested | Added `as never` to allowlist; test cases added |
+| WR-02 | Chained unsafe cast untested | Test case added — 2 errors verified |
+| WR-03 | Double-flagging with `objectLiteralTypeAssertions: 'never'` | Option dropped from `consistent-type-assertions`; new rule is sole enforcer |
+| IN-01 | Missing comment on `as const` detection | Inline comment added explaining `TSTypeReference` vs `TSTypeOperator` in v8 |
+| IN-02 | `value as unknown as T` (no parens) not in valid cases | Added no-parens form to valid test cases |

--- a/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-SUMMARY.md
+++ b/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-SUMMARY.md
@@ -1,0 +1,76 @@
+---
+phase: quick
+plan: 260505-t76
+subsystem: eslint-plugin
+tags: [eslint, rules, config, strict]
+dependency_graph:
+  requires: []
+  provides: [no-unsafe-type-assertion rule, strict config fixes]
+  affects: [eslint-plugin/src/rules, eslint-plugin/src/configs/strict.ts]
+tech_stack:
+  added: []
+  patterns: [ESLint custom rule, TSAsExpression visitor]
+key_files:
+  created:
+    - eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+    - eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
+  modified:
+    - eslint-plugin/src/rules/index.ts
+    - eslint-plugin/src/configs/strict.ts
+    - eslint-plugin/tests/configs/strict.test.ts
+decisions:
+  - as-const detection uses TSTypeReference.typeName.name==='const' not TSTypeOperator in @typescript-eslint v8
+  - naming-convention types property not supported in v8 schema so PascalCase-object-namespace entry omitted
+metrics:
+  duration: 15min
+  completed_date: "2026-05-05"
+---
+
+# Quick Task 260505-t76: Address Vetted GitHub Issues — Add no-unsafe-type-assertion
+
+**One-liner:** Added `no-unsafe-type-assertion` rule (allow `as unknown` and `(x as unknown) as T` only) and fixed five strict config issues — consistent-type-assertions, naming-convention classProperty, no-unnecessary-condition, no-unused-vars, and enabled new rule.
+
+## Tasks Completed
+
+| # | Task | Commit | Files |
+|---|------|--------|-------|
+| 1 | Create no-unsafe-type-assertion rule, test, register | 0f00845 | src/rules/no-unsafe-type-assertion.ts, tests/rules/no-unsafe-type-assertion.test.ts, src/rules/index.ts |
+| 2 | Fix strict config (#30–#33) + update strict.test.ts | d1b6691 | src/configs/strict.ts, src/rules/no-unsafe-type-assertion.ts (bug fix), tests/configs/strict.test.ts |
+
+## Verification
+
+`npm run build && npm test && npm run typecheck` in `eslint-plugin/` — all 55 tests pass, build and typecheck clean.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed `as const` detection in no-unsafe-type-assertion rule**
+- **Found during:** Task 3 (verification)
+- **Issue:** The plan's rule implementation used `typeAnnotation.type === 'TSTypeOperator' && typeAnnotation.operator === 'const'` but in @typescript-eslint v8.x, `as const` is parsed as `TSTypeReference` with `typeName.name === 'const'`, not `TSTypeOperator`. The `as const` valid cases failed the tests.
+- **Fix:** Changed the `as const` check to `typeAnnotation.type === 'TSTypeReference' && typeAnnotation.typeName.type === 'Identifier' && typeAnnotation.typeName.name === 'const'`
+- **Files modified:** `eslint-plugin/src/rules/no-unsafe-type-assertion.ts`
+- **Commit:** d1b6691
+
+### Plan Items Not Implementable
+
+**2. [#31 fix 2] naming-convention `types` property not supported in @typescript-eslint v8 schema**
+- **Issue:** The plan called for adding `{ selector: 'variable', modifiers: ['const', 'global'], types: ['object'], format: ['camelCase', 'UPPER_CASE', 'PascalCase'] }` to naming-convention. However, `types` is not in the JSON schema for `@typescript-eslint/naming-convention` in the installed v8.59.0 — ESLint schema validation rejects it as an unexpected property.
+- **Decision:** Omitted the entry. The `classProperty`/`leadingUnderscore` fix (fix 1 of #31) was implemented successfully. The PascalCase-for-object-namespaces intent (fix 2) cannot be expressed without `types` support.
+- **Impact:** Users who want to name const namespace objects in PascalCase will see a naming-convention violation. This is a known limitation logged here for future resolution when `types` support is available.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, or trust boundary changes.
+
+## Self-Check: PASSED
+
+- [x] `eslint-plugin/src/rules/no-unsafe-type-assertion.ts` — exists
+- [x] `eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts` — exists
+- [x] Commit 0f00845 — exists
+- [x] Commit d1b6691 — exists
+- [x] All 55 tests pass

--- a/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-SUMMARY.md
+++ b/.planning/quick/260505-t76-address-vetted-github-issues-add-no-unsa/260505-t76-SUMMARY.md
@@ -28,7 +28,7 @@ metrics:
 
 # Quick Task 260505-t76: Address Vetted GitHub Issues — Add no-unsafe-type-assertion
 
-**One-liner:** Added `no-unsafe-type-assertion` rule (allow `as unknown` and `(x as unknown) as T` only) and fixed five strict config issues — consistent-type-assertions, naming-convention classProperty, no-unnecessary-condition, no-unused-vars, and enabled new rule.
+**One-liner:** Added `no-unsafe-type-assertion` rule (allow `as unknown`, `(x as unknown) as T`, `as const`, `as never`) and fixed five strict config issues — consistent-type-assertions, naming-convention classProperty + PascalCase variables, no-unnecessary-condition, no-unused-vars, and enabled new rule.
 
 ## Tasks Completed
 
@@ -56,8 +56,8 @@ metrics:
 
 **2. [#31 fix 2] naming-convention `types` property not supported in @typescript-eslint v8 schema**
 - **Issue:** The plan called for adding `{ selector: 'variable', modifiers: ['const', 'global'], types: ['object'], format: ['camelCase', 'UPPER_CASE', 'PascalCase'] }` to naming-convention. However, `types` is not in the JSON schema for `@typescript-eslint/naming-convention` in the installed v8.59.0 — ESLint schema validation rejects it as an unexpected property.
-- **Decision:** Omitted the entry. The `classProperty`/`leadingUnderscore` fix (fix 1 of #31) was implemented successfully. The PascalCase-for-object-namespaces intent (fix 2) cannot be expressed without `types` support.
-- **Impact:** Users who want to name const namespace objects in PascalCase will see a naming-convention violation. This is a known limitation logged here for future resolution when `types` support is available.
+- **Decision:** Added `PascalCase` to the global `variable` format list (`['camelCase', 'UPPER_CASE', 'PascalCase']`) instead. This is broader than intended but unblocks namespace-style const objects. The `docs/opinions/naming-convention.md` opinion has been updated to reflect this.
+- **Impact:** PascalCase is now allowed for all `variable` identifiers (not just object-typed ones). The opinion notes that PascalCase on a plain scalar (e.g., `const MaxRetries = 3`) is still bad style — the lint rule cannot distinguish without `types` support.
 
 ## Known Stubs
 

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,6 +1,6 @@
 # Traceability Matrix
 
-Generated: 2026-03-20 | Opinions: 59 | Covered: 35 | Skill-only: 24 | Gaps: 0
+Generated: 2026-05-06 | Opinions: 60 | Covered: 35 | Skill-only: 24 | Gaps: 1
 
 ## Coverage
 
@@ -38,6 +38,7 @@ Generated: 2026-03-20 | Opinions: 59 | Covered: 35 | Skill-only: 24 | Gaps: 0
 | no-unnecessary-condition | Do not write conditions that are always true or false | B | both | null-handling.md | @typescript-eslint/no-unnecessary-condition | covered |
 | no-unnecessary-generics | Do not add type parameters used only once | M | both | generics.md | @typescript-eslint/no-unnecessary-type-parameters | covered |
 | no-unsafe-return | Do not return unsafe any-typed values | B | both | type-safety.md | @typescript-eslint/no-unsafe-return | covered |
+| no-unsafe-type-assertion | Permit only safe type assertion patterns | B | both | type-safety.md | typescript-narrows/no-unsafe-type-assertion | covered |
 | no-var | Never use var | S | both | immutability.md | no-var | covered |
 | prefer-arrow-functions | Use arrow functions by default | S | skill-only | functions.md | -- | skill-only |
 | prefer-async-await | Use async/await over .then() chains | M | skill-only | async-promises.md | -- | skill-only |
@@ -49,7 +50,7 @@ Generated: 2026-03-20 | Opinions: 59 | Covered: 35 | Skill-only: 24 | Gaps: 0
 | prefer-nullish-coalescing | Use ?? instead of || for nullish fallbacks | B | both | null-handling.md | @typescript-eslint/prefer-nullish-coalescing | covered |
 | prefer-optional-chaining | Use optional chaining over manual null checks | S | both | null-handling.md | @typescript-eslint/prefer-optional-chain | covered |
 | prefer-readonly | Mark class properties readonly when not reassigned | M | both | immutability.md | @typescript-eslint/prefer-readonly | covered |
-| prefer-readonly-params | Use Readonly<T> and ReadonlyArray<T> in function params | M | both | immutability.md | @typescript-eslint/prefer-readonly-parameter-types | covered |
+| prefer-readonly-params | Use Readonly<T> and ReadonlyArray<T> in function params | M | both | immutability.md | @typescript-eslint/prefer-readonly-parameter-types | gap |
 | prefer-undefined | Prefer undefined over null | S | skill-only | null-handling.md | -- | skill-only |
 | prefer-unknown | Use unknown for values of uncertain type | B | both | type-safety.md | @typescript-eslint/no-unsafe-assignment | covered |
 | prefer-using-declarations | Use `using` declarations to tie resource lifetimes to scope | B | skill-only | resource-management.md | -- | skill-only |
@@ -68,4 +69,6 @@ Generated: 2026-03-20 | Opinions: 59 | Covered: 35 | Skill-only: 24 | Gaps: 0
 
 ## Gaps
 
-(none)
+| Opinion ID | Title | Enforcement | Issue |
+|------------|-------|-------------|-------|
+| prefer-readonly-params | Use Readonly<T> and ReadonlyArray<T> in function params | both | lint rule not in strict config |

--- a/docs/opinions/INDEX.md
+++ b/docs/opinions/INDEX.md
@@ -9,6 +9,7 @@ Severity: B = bug-prevention, M = maintenance, S = style | Enforcement: both, sk
 - [no-explicit-any](no-explicit-any.md) -- Never use explicit `any` [B] [both]
 - [prefer-unknown](prefer-unknown.md) -- Use `unknown` for values of uncertain type [B] [both]
 - [no-type-assertions](no-type-assertions.md) -- Restrict type assertions to proven-safe patterns [B] [both]
+- [no-unsafe-type-assertion](no-unsafe-type-assertion.md) -- Permit only safe type assertion patterns [B] [both]
 - [no-non-null-assertion](no-non-null-assertion.md) -- Do not use the `!` postfix operator [B] [both]
 - [strict-boolean-expressions](strict-boolean-expressions.md) -- Require explicit boolean comparisons [B] [both]
 - [use-unknown-in-catch](use-unknown-in-catch.md) -- Type catch clause variables as `unknown` [B] [both]

--- a/docs/opinions/naming-convention.md
+++ b/docs/opinions/naming-convention.md
@@ -13,11 +13,13 @@ lint:
 
 ## Stance
 
-Use PascalCase for types, interfaces, classes, and enums. Use camelCase for variables, functions, methods, and parameters. Use UPPER_CASE for module-level constants. For build-time injected constants supplied by tooling, `__NAME__` is also allowed.
+Use PascalCase for types, interfaces, classes, and enums. Use camelCase for variables, functions, methods, and parameters. Use UPPER_CASE for module-level constants. PascalCase is also allowed for variables that represent namespace-style const objects (e.g., `const Body = { none, json } as const`). For build-time injected constants supplied by tooling, `__NAME__` is also allowed.
 
 ## Why
 
-Consistent casing makes it immediately clear whether a symbol is a type or a value. This is the dominant convention in the TypeScript ecosystem. When the entire codebase follows the same rules, you never have to guess whether `UserProfile` is a class or a variable -- the casing tells you.
+Consistent casing makes it immediately clear whether a symbol is a type or a value. This is the dominant convention in the TypeScript ecosystem. When the entire codebase follows the same rules, you never have to guess whether `UserProfile` is a class or a variable — the casing tells you.
+
+PascalCase namespace objects (analogous to built-ins like `Math`, `JSON`, `Array`) are a recognized TypeScript idiom for grouping related values. Banning PascalCase for all variables would force awkward renames like `body` or `BODY` for objects that are conceptually namespace-like.
 
 ## Do
 
@@ -29,6 +31,10 @@ interface UserProfile {
 const maxRetries = 3;
 const MAX_TIMEOUT = 5000;
 declare const __APP_RUNTIME_TARGET__: 'browser' | 'node';
+
+// Namespace-style const object — PascalCase is allowed
+const Body = { none: 'none', json: 'json', text: 'text' } as const;
+type Body = (typeof Body)[keyof typeof Body];
 
 function formatName(user: UserProfile): string {
   return user.displayName;
@@ -42,6 +48,7 @@ interface userProfile {
   DisplayName: string;
 }
 
+// PascalCase for a plain scalar — use camelCase or UPPER_CASE instead
 const MaxRetries = 3;
 const max_timeout = 5000;
 ```

--- a/docs/opinions/no-type-assertions.md
+++ b/docs/opinions/no-type-assertions.md
@@ -5,7 +5,7 @@ severity: bug-prevention
 enforcement: both
 confidence: strong
 tags: [type-safety, assertions]
-related: [no-explicit-any, use-type-narrowing]
+related: [no-unsafe-type-assertion, use-type-narrowing, no-explicit-any]
 lint:
   type: existing
   rule: "@typescript-eslint/consistent-type-assertions"
@@ -13,7 +13,7 @@ lint:
 
 ## Stance
 
-Do not use `as` type assertions unless narrowing is impossible and the assertion is provably safe.
+Do not use `as` type assertions unless narrowing is impossible and the assertion is provably safe. When an assertion is necessary, use the `as unknown as T` double-cast pattern — see [no-unsafe-type-assertion](no-unsafe-type-assertion.md).
 
 ## Why
 

--- a/docs/opinions/no-unsafe-type-assertion.md
+++ b/docs/opinions/no-unsafe-type-assertion.md
@@ -1,0 +1,71 @@
+---
+id: no-unsafe-type-assertion
+title: Permit only safe type assertion patterns
+severity: bug-prevention
+enforcement: both
+confidence: strong
+tags: [type-safety, assertions]
+related: [no-type-assertions, use-type-narrowing, prefer-unknown]
+lint:
+  type: custom
+  rule: "typescript-narrows/no-unsafe-type-assertion"
+---
+
+## Stance
+
+Only the following type assertion forms are permitted:
+
+| Pattern | Reason |
+|---------|--------|
+| `x as unknown` | Safe upcast — always valid |
+| `x as unknown as T` | Explicit type boundary crossing — intent is clear |
+| `x as const` | Const assertion — unrelated semantics |
+| `x as never` | Exhaustiveness-check helper — `assertNever(x as never)` |
+
+All other `as` assertions (`x as string`, `{} as Foo`, etc.) are banned.
+
+## Why
+
+Bare `as T` assertions silently override the compiler. A union member can be asserted away without any runtime check:
+
+```typescript
+const result: { kind: 'success' } | { kind: 'error' } = getResult();
+const ok = result as { kind: 'success' }; // compiles; crashes at runtime
+```
+
+The `as unknown as T` double-cast makes the intent explicit: you are knowingly crossing a type boundary. It reads as a deliberate choice, not an accidental shortcut, and is easy to grep for in a codebase.
+
+## Do
+
+```typescript
+// Safe upcast
+const raw = value as unknown;
+
+// Explicit type boundary (opaque/branded type construction)
+const userId = (rawId as unknown) as UserId;
+
+// Const assertion
+const config = { host: 'localhost', port: 3000 } as const;
+
+// Exhaustiveness helper
+function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${x as never}`);
+}
+```
+
+## Don't
+
+```typescript
+// Bare assertion — bypasses the compiler silently
+const user = data as User;
+
+// Object literal assertion — TypeScript skips excess-property checks
+const req = {} as Request;
+
+// Chained unsafe assertion
+const typed = (value as Foo) as Bar;
+```
+
+## Exceptions
+
+`as unknown` is always allowed and is the correct first step when a double-cast is needed. Test fixtures may use `as unknown as T` for controlled stubs.

--- a/eslint-plugin/src/configs/strict.ts
+++ b/eslint-plugin/src/configs/strict.ts
@@ -83,7 +83,7 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
             format: null,
           },
           { selector: 'default', format: ['camelCase'] },
-          { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
+          { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'] },
           {
             selector: 'parameter',
             format: ['camelCase'],

--- a/eslint-plugin/src/configs/strict.ts
+++ b/eslint-plugin/src/configs/strict.ts
@@ -36,7 +36,10 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
         '@typescript-eslint/no-namespace': 'error',
         '@typescript-eslint/switch-exhaustiveness-check': 'error',
         '@typescript-eslint/prefer-optional-chain': 'error',
-        '@typescript-eslint/no-unnecessary-condition': 'error',
+        '@typescript-eslint/no-unnecessary-condition': [
+          'error',
+          { allowConstantLoopConditions: true },
+        ],
         '@typescript-eslint/prefer-nullish-coalescing': 'error',
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-misused-promises': 'error',
@@ -46,7 +49,10 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
         '@typescript-eslint/no-unnecessary-type-parameters': 'error',
         '@typescript-eslint/consistent-type-assertions': [
           'error',
-          { assertionStyle: 'never' },
+          {
+            assertionStyle: 'as',
+            objectLiteralTypeAssertions: 'never',
+          },
         ],
 
         // @typescript-eslint rules NOT in strict-type-checked (7, explicitly added)
@@ -83,6 +89,11 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
             format: ['camelCase'],
             leadingUnderscore: 'allow',
           },
+          {
+            selector: 'classProperty',
+            format: ['camelCase'],
+            leadingUnderscore: 'allow',
+          },
           { selector: 'typeLike', format: ['PascalCase'] },
           { selector: 'enumMember', format: ['PascalCase'] },
           {
@@ -97,9 +108,22 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
           },
         ],
 
-        // typescript-narrows custom rules (2)
+        // typescript-narrows custom rules (3)
         'typescript-narrows/ban-enums': 'error',
         'typescript-narrows/ban-barrel-files': 'error',
+        'typescript-narrows/no-unsafe-type-assertion': 'error',
+
+        // @typescript-eslint/no-unused-vars explicit options
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            args: 'all',
+            argsIgnorePattern: '^_',
+            caughtErrorsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            ignoreRestSiblings: true,
+          },
+        ],
       },
     },
   ];

--- a/eslint-plugin/src/configs/strict.ts
+++ b/eslint-plugin/src/configs/strict.ts
@@ -49,10 +49,7 @@ export function createStrictConfig(plugin: ESLint.Plugin): Linter.Config[] {
         '@typescript-eslint/no-unnecessary-type-parameters': 'error',
         '@typescript-eslint/consistent-type-assertions': [
           'error',
-          {
-            assertionStyle: 'as',
-            objectLiteralTypeAssertions: 'never',
-          },
+          { assertionStyle: 'as' },
         ],
 
         // @typescript-eslint rules NOT in strict-type-checked (7, explicitly added)

--- a/eslint-plugin/src/rules/index.ts
+++ b/eslint-plugin/src/rules/index.ts
@@ -1,7 +1,9 @@
 import { banEnums } from './ban-enums.js';
 import { banBarrelFiles } from './ban-barrel-files.js';
+import { noUnsafeTypeAssertion } from './no-unsafe-type-assertion.js';
 
 export const rules = {
   'ban-enums': banEnums,
   'ban-barrel-files': banBarrelFiles,
+  'no-unsafe-type-assertion': noUnsafeTypeAssertion,
 };

--- a/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -1,0 +1,43 @@
+import { createRule } from '../utils/create-rule.js';
+
+export const noUnsafeTypeAssertion = createRule({
+  name: 'no-unsafe-type-assertion',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Permit only as-unknown and double-cast-through-unknown type assertion patterns',
+      opinionId: 'no-unsafe-type-assertion',
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      unsafeAssertion: 'Unsafe type assertion. Use `as unknown as T` to cross a type boundary explicitly, or eliminate the assertion with a type guard.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSAsExpression(node) {
+        const { typeAnnotation } = node;
+
+        // Allow: x as unknown
+        if (typeAnnotation.type === 'TSUnknownKeyword') return;
+
+        // Allow: x as const
+        if (
+          typeAnnotation.type === 'TSTypeOperator' &&
+          typeAnnotation.operator === 'const'
+        ) return;
+
+        // Allow: (x as unknown) as T — the inner expression is a TSAsExpression whose type is TSUnknownKeyword
+        if (
+          node.expression.type === 'TSAsExpression' &&
+          node.expression.typeAnnotation.type === 'TSUnknownKeyword'
+        ) return;
+
+        context.report({ node, messageId: 'unsafeAssertion' });
+      },
+    };
+  },
+});

--- a/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -24,14 +24,19 @@ export const noUnsafeTypeAssertion = createRule({
         // Allow: x as unknown
         if (typeAnnotation.type === 'TSUnknownKeyword') return;
 
+        // Allow: x as never  (exhaustiveness-check pattern: assertNever(x as never))
+        if (typeAnnotation.type === 'TSNeverKeyword') return;
+
         // Allow: x as const
+        // Note: in @typescript-eslint v8, `as const` parses as TSTypeReference{typeName:'const'},
+        // not TSTypeOperator — verified against the upstream isConst() helper.
         if (
           typeAnnotation.type === 'TSTypeReference' &&
           typeAnnotation.typeName.type === 'Identifier' &&
           typeAnnotation.typeName.name === 'const'
         ) return;
 
-        // Allow: (x as unknown) as T — the inner expression is a TSAsExpression whose type is TSUnknownKeyword
+        // Allow: (x as unknown) as T  (double-cast through unknown, with or without parens)
         if (
           node.expression.type === 'TSAsExpression' &&
           node.expression.typeAnnotation.type === 'TSUnknownKeyword'

--- a/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -5,7 +5,7 @@ export const noUnsafeTypeAssertion = createRule({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Permit only as-unknown and double-cast-through-unknown type assertion patterns',
+      description: 'Permit only safe type assertion patterns: as unknown, (x as unknown) as T, as const, and as never',
       opinionId: 'no-unsafe-type-assertion',
       recommended: true,
       requiresTypeChecking: false,

--- a/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -26,8 +26,9 @@ export const noUnsafeTypeAssertion = createRule({
 
         // Allow: x as const
         if (
-          typeAnnotation.type === 'TSTypeOperator' &&
-          typeAnnotation.operator === 'const'
+          typeAnnotation.type === 'TSTypeReference' &&
+          typeAnnotation.typeName.type === 'Identifier' &&
+          typeAnnotation.typeName.name === 'const'
         ) return;
 
         // Allow: (x as unknown) as T — the inner expression is a TSAsExpression whose type is TSUnknownKeyword

--- a/eslint-plugin/tests/configs/strict.test.ts
+++ b/eslint-plugin/tests/configs/strict.test.ts
@@ -127,7 +127,7 @@ describe('strict config preset', () => {
     const cta = allRules['@typescript-eslint/consistent-type-assertions'] as [string, Record<string, unknown>];
     expect(cta[0]).toBe('error');
     expect(cta[1].assertionStyle).toBe('as');
-    expect(cta[1].objectLiteralTypeAssertions).toBe('never');
+    expect(cta[1].objectLiteralTypeAssertions).toBeUndefined();
   });
 
   it('configures no-unnecessary-condition with allowConstantLoopConditions (#32)', () => {

--- a/eslint-plugin/tests/configs/strict.test.ts
+++ b/eslint-plugin/tests/configs/strict.test.ts
@@ -59,6 +59,13 @@ describe('strict config preset', () => {
       modifiers: ['requiresQuotes'],
       format: null,
     });
+
+    // #31 fix 1: classProperty with leadingUnderscore allow
+    expect(namingConvention.slice(1)).toContainEqual({
+      selector: 'classProperty',
+      format: ['camelCase'],
+      leadingUnderscore: 'allow',
+    });
   });
 
   it('configures import plugin rules', () => {
@@ -97,4 +104,68 @@ describe('strict config preset', () => {
     });
     expect(hasNarrowsPlugin).toBe(true);
   });
+
+  it('registers no-unsafe-type-assertion rule in plugin', () => {
+    expect(plugin.rules).toBeDefined();
+    expect((plugin.rules as Record<string, unknown>)['no-unsafe-type-assertion']).toBeDefined();
+  });
+
+  it('configures consistent-type-assertions with assertionStyle: as (#30)', () => {
+    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+    for (const config of strict) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    const cta = allRules['@typescript-eslint/consistent-type-assertions'] as [string, Record<string, unknown>];
+    expect(cta[0]).toBe('error');
+    expect(cta[1].assertionStyle).toBe('as');
+    expect(cta[1].objectLiteralTypeAssertions).toBe('never');
+  });
+
+  it('configures no-unnecessary-condition with allowConstantLoopConditions (#32)', () => {
+    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+    for (const config of strict) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    const nuc = allRules['@typescript-eslint/no-unnecessary-condition'] as [string, Record<string, unknown>];
+    expect(nuc[0]).toBe('error');
+    expect(nuc[1].allowConstantLoopConditions).toBe(true);
+  });
+
+  it('configures no-unused-vars with argsIgnorePattern (#33)', () => {
+    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+    for (const config of strict) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    const nuv = allRules['@typescript-eslint/no-unused-vars'] as [string, Record<string, unknown>];
+    expect(nuv[0]).toBe('error');
+    expect(nuv[1].argsIgnorePattern).toBe('^_');
+    expect(nuv[1].caughtErrorsIgnorePattern).toBe('^_');
+    expect(nuv[1].varsIgnorePattern).toBe('^_');
+    expect(nuv[1].ignoreRestSiblings).toBe(true);
+  });
+
+  it('enables no-unsafe-type-assertion in strict config (#29)', () => {
+    const strict = (plugin.configs as Record<string, unknown>).strict as Array<Record<string, unknown>>;
+    const allRules: Record<string, unknown> = {};
+    for (const config of strict) {
+      if (config.rules) {
+        Object.assign(allRules, config.rules as Record<string, unknown>);
+      }
+    }
+
+    expect(allRules['typescript-narrows/no-unsafe-type-assertion']).toBe('error');
+  });
 });
+

--- a/eslint-plugin/tests/configs/strict.test.ts
+++ b/eslint-plugin/tests/configs/strict.test.ts
@@ -66,6 +66,11 @@ describe('strict config preset', () => {
       format: ['camelCase'],
       leadingUnderscore: 'allow',
     });
+    // #31 fix 2: PascalCase allowed for variables
+    expect(namingConvention.slice(1)).toContainEqual({
+      selector: 'variable',
+      format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+    });
   });
 
   it('configures import plugin rules', () => {

--- a/eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
+++ b/eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
@@ -7,8 +7,10 @@ ruleTester.run('no-unsafe-type-assertion', noUnsafeTypeAssertion, {
   valid: [
     'const u = value as unknown;',
     'const b = (value as unknown) as BodyOpaque;',
+    'const b2 = value as unknown as BodyOpaque;',
     'const c = { x: 1 } as const;',
     'const d = [1, 2] as const;',
+    'const n = value as never;',
   ],
   invalid: [
     {
@@ -26,6 +28,13 @@ ruleTester.run('no-unsafe-type-assertion', noUnsafeTypeAssertion, {
     {
       code: 'const g = value as SomeClass;',
       errors: [{ messageId: 'unsafeAssertion' as const }],
+    },
+    {
+      code: 'const h = (value as Foo) as Bar;',
+      errors: [
+        { messageId: 'unsafeAssertion' as const },
+        { messageId: 'unsafeAssertion' as const },
+      ],
     },
   ],
 });

--- a/eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
+++ b/eslint-plugin/tests/rules/no-unsafe-type-assertion.test.ts
@@ -1,0 +1,31 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noUnsafeTypeAssertion } from '../../src/rules/no-unsafe-type-assertion.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unsafe-type-assertion', noUnsafeTypeAssertion, {
+  valid: [
+    'const u = value as unknown;',
+    'const b = (value as unknown) as BodyOpaque;',
+    'const c = { x: 1 } as const;',
+    'const d = [1, 2] as const;',
+  ],
+  invalid: [
+    {
+      code: 'const a = value as string;',
+      errors: [{ messageId: 'unsafeAssertion' as const }],
+    },
+    {
+      code: 'const e = result as { kind: string };',
+      errors: [{ messageId: 'unsafeAssertion' as const }],
+    },
+    {
+      code: 'const f = {} as SomeInterface;',
+      errors: [{ messageId: 'unsafeAssertion' as const }],
+    },
+    {
+      code: 'const g = value as SomeClass;',
+      errors: [{ messageId: 'unsafeAssertion' as const }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Closes #29, #30, #31, #32, #33.

---

## Changes

### #29 — New rule: `no-unsafe-type-assertion`

Permits only safe type assertion patterns:

| Pattern | Allowed |
|---------|---------|
| `x as unknown` | ✅ safe upcast |
| `(x as unknown) as T` / `x as unknown as T` | ✅ explicit type boundary crossing |
| `x as const` | ✅ const assertion |
| `x as never` | ✅ exhaustiveness-check pattern |
| `x as string` | ❌ |
| `{} as Foo` | ❌ |

### #30 — `consistent-type-assertions`: relax to `assertionStyle: 'as'`

Drops the blanket `assertionStyle: 'never'` now that `no-unsafe-type-assertion` handles substantive enforcement. Bans only the deprecated angle-bracket syntax. `objectLiteralTypeAssertions: 'never'` also dropped — fully subsumed by the new rule.

### #31 — `naming-convention` fixes

- Allow `leadingUnderscore` on `classProperty` (e.g. `private readonly _kind`)
- Allow `PascalCase` for variables (enables namespace-style const objects like `const Body = { ... }`)

### #32 — `no-unnecessary-condition`: allow constant loop conditions

Adds `allowConstantLoopConditions: true` so `while (true) { ... break; }` is not flagged.

### #33 — `no-unused-vars`: respect `_`-prefix convention

Adds explicit ignore patterns to honor the `_param` convention already established by `naming-convention`.

---

## Test coverage

58 tests passing (+11 new). Build and typecheck clean.