### PR TITLE
chore(eslint-plugin): bump version to 1.3.0

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -11,7 +11,7 @@ The user provides `$ARGUMENTS` which should specify what to release. Examples:
 
 ### For the ESLint plugin (`eslint-plugin/v*` tags):
 
-1. Update `eslint-plugin/package.json` version field to the new version
+1. Run `cd eslint-plugin && npm version {version} --no-git-tag-version --allow-same-version` to update both `package.json` and `package-lock.json`
 2. Run `cd eslint-plugin && npm run build && npm test && npm run typecheck` to verify everything passes
 3. Commit on a branch: `chore(eslint-plugin): bump version to {version}`
 4. Open and merge a PR so the version bump lands on protected `main`

--- a/eslint-plugin/package-lock.json
+++ b/eslint-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0",

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump to 1.3.0 for release.

## Changes since 1.2.1

- feat: add `no-unsafe-type-assertion` rule (allows `as unknown`, `(x as unknown) as T`, `as const`, `as never`)
- fix: `consistent-type-assertions` — switch from `assertionStyle: never` to `as` style
- fix: `naming-convention` — allow `leadingUnderscore` on `classProperty`; allow PascalCase for variables
- fix: `no-unnecessary-condition` — add `allowConstantLoopConditions: true`
- fix: `no-unused-vars` — add `^\_` ignore patterns
- deps: bump minimatch (dependabot)