### PR TITLE
docs(opinions): document no-unnecessary-type-assertion conflict resolution

### DIFF
--- a/docs/opinions/no-unsafe-type-assertion.md
+++ b/docs/opinions/no-unsafe-type-assertion.md
@@ -69,3 +69,9 @@ const typed = (value as Foo) as Bar;
 ## Exceptions
 
 `as unknown` is always allowed and is the correct first step when a double-cast is needed. Test fixtures may use `as unknown as T` for controlled stubs.
+
+## Rule interaction: `@typescript-eslint/no-unnecessary-type-assertion`
+
+The `strict` preset disables `@typescript-eslint/no-unnecessary-type-assertion`. The reason is a direct conflict: when a variable is already typed `unknown`, the required double-cast pattern `(x as unknown) as T` would trigger that rule on the inner `as unknown`, which it considers redundant. Keeping both rules active makes the double-cast pattern impossible to write without a per-line suppression comment.
+
+Disabling `no-unnecessary-type-assertion` is safe because `typescript-narrows/no-unsafe-type-assertion` is a strict syntactic superset: it catches every dangerous assertion that `no-unnecessary-type-assertion` would catch, plus more. No safety coverage is lost.


### PR DESCRIPTION
## What

Documents the rule interaction between `typescript-narrows/no-unsafe-type-assertion` and `@typescript-eslint/no-unnecessary-type-assertion` in the opinion corpus.

## Why

The `strict` preset disables `@typescript-eslint/no-unnecessary-type-assertion` (landed in the preceding commit on `main`). Without documentation in the opinion file, the rationale is invisible and the next person to look at `strict.ts` may remove the override as seemingly unnecessary.

## Rationale for disabling

When a variable is already typed `unknown`, the required double-cast pattern `(x as unknown) as T` triggers `no-unnecessary-type-assertion` on the inner `as unknown`, creating an inescapable conflict. Disabling is safe because `typescript-narrows/no-unsafe-type-assertion` is a strict syntactic superset — it catches every dangerous assertion that the TS rule would catch, plus more.

## Release note

This PR completes the `1.3.1` fix. After merge, push `eslint-plugin/v1.3.1` to trigger the release workflow.