### PR TITLE
chore(eslint-plugin): bump version to 1.3.3

### DIFF
--- a/eslint-plugin/package-lock.json
+++ b/eslint-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0",

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sethlivingston/eslint-plugin-typescript-narrows",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Opinionated ESLint plugin for TypeScript",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `eslint-plugin` to 1.3.3, recovering from a botched release where `eslint-plugin/v1.3.2` and `plugin/v1.1.1` tags were pushed against the wrong commit (`d885ad4`, an old dependabot-merge commit whose `package.json` was still at 1.3.1).
- The release workflow's tag/version verification correctly rejected the bad `v1.3.2` tag (no npm package or GitHub release was created from it), and that dead tag has been deleted.

## Test plan
- [x] `npm run build`
- [x] `npm test` (58 passed)
- [x] `npm run typecheck`